### PR TITLE
Add FailNow, Attachment and NewAttachment in stepctx interface

### DIFF
--- a/examples/allure_go_compare/attachments_test.go
+++ b/examples/allure_go_compare/attachments_test.go
@@ -18,7 +18,7 @@ type AllureGoAttachments struct {
 /* Allure-Go style:
 func TestTextAttachment(t *testing.T) {
 	allure.Test(t, allure.Description("Testing a text attachment"), allure .Action(func() {
-		_ = allure.AddAttachment("text!", allure.TextPlain, []byte("Some text!"))
+		_ = allure.AddAttachments("text!", allure.TextPlain, []byte("Some text!"))
 	}))
 }
 */
@@ -26,14 +26,14 @@ func TestTextAttachment(t *testing.T) {
 func (s *AllureGoAttachments) TestTextAttachment(t provider.T) {
 	t.Epic("Compare with allure-go")
 	t.Description("Testing a text attachment")
-	t.Attachment(allure.NewAttachment("text!", allure.Text, []byte("Some text!")))
+	t.WithAttachments(allure.NewAttachment("text!", allure.Text, []byte("Some text!")))
 }
 
 /* TestTextAttachmentToStep Allure-Go style:
 func TestTextAttachmentToStep(t *testing.T) {
 	allure.Test(t, allure.Description("Testing a text attachment"), allure.Action(func() {
 		allure.Step(allure.Description("adding a text attachment"), allure.Action(func() {
-			_ = allure.AddAttachment("text!", allure.TextPlain, []byte("Some text!"))
+			_ = allure.AddAttachments("text!", allure.TextPlain, []byte("Some text!"))
 		}))
 	}))
 }

--- a/examples/suite_demo/attachments_test.go
+++ b/examples/suite_demo/attachments_test.go
@@ -30,7 +30,7 @@ func (s *AttachmentTestDemoSuite) TestAttachment(t provider.T) {
 	t.Tags("Attachments", "BeforeAfter", "Steps")
 
 	attachmentText := `THIS IS A TEXT ATTACHMENT`
-	t.Attachment(allure.NewAttachment("Text Attachment if TestAttachment", allure.Text, []byte(attachmentText)))
+	t.WithAttachments(allure.NewAttachment("Text Attachment if TestAttachment", allure.Text, []byte(attachmentText)))
 
 	step := allure.NewSimpleStep("Step A")
 	var ExampleJson = JSONStruct{"this is JSON message"}
@@ -46,7 +46,7 @@ type AttachmentDemoSuite struct {
 func (s *AttachmentDemoSuite) BeforeAll(t provider.T) {
 	// this action will create a step in Set up
 	attachmentText := `THIS IS A TEXT ATTACHMENT`
-	t.Attachment(allure.NewAttachment("Text Attachment for Before suite", allure.Text, []byte(attachmentText)))
+	t.WithAttachments(allure.NewAttachment("Text Attachment for Before suite", allure.Text, []byte(attachmentText)))
 
 	step := allure.NewSimpleStep("Before suite Step")
 	var ExampleJson = JSONStruct{"This is BeforeAll JSON message"}
@@ -58,7 +58,7 @@ func (s *AttachmentDemoSuite) BeforeAll(t provider.T) {
 func (s *AttachmentDemoSuite) BeforeEach(t provider.T) {
 	// this action will create a step in Set up
 	attachmentText := `THIS IS A TEXT ATTACHMENT`
-	t.Attachment(allure.NewAttachment("Text Attachment for Before Test", allure.Text, []byte(attachmentText)))
+	t.WithAttachments(allure.NewAttachment("Text Attachment for Before Test", allure.Text, []byte(attachmentText)))
 
 	step := allure.NewSimpleStep("Before Test Step")
 	var ExampleJson = JSONStruct{"This is BeforeEach JSON message"}
@@ -70,7 +70,7 @@ func (s *AttachmentDemoSuite) BeforeEach(t provider.T) {
 func (s *AttachmentDemoSuite) AfterAll(t provider.T) {
 	// this action will create a step in Tear down
 	attachmentText := `THIS IS A TEXT ATTACHMENT`
-	t.Attachment(allure.NewAttachment("Text Attachment for After suite", allure.Text, []byte(attachmentText)))
+	t.WithAttachments(allure.NewAttachment("Text Attachment for After suite", allure.Text, []byte(attachmentText)))
 
 	step := allure.NewSimpleStep("After suite Step")
 	var ExampleJson = JSONStruct{"This is AfterAll JSON message"}
@@ -82,7 +82,7 @@ func (s *AttachmentDemoSuite) AfterAll(t provider.T) {
 func (s *AttachmentDemoSuite) AfterEach(t provider.T) {
 	// this action will create a step in Tear down
 	attachmentText := `THIS IS A TEXT ATTACHMENT`
-	t.Attachment(allure.NewAttachment("Text Attachment for After Test", allure.Text, []byte(attachmentText)))
+	t.WithAttachments(allure.NewAttachment("Text Attachment for After Test", allure.Text, []byte(attachmentText)))
 
 	step := allure.NewSimpleStep("After Test Step")
 	var ExampleJson = JSONStruct{"This is AfterEach JSON message"}

--- a/pkg/framework/core/allure_manager/ctx/hooks.go
+++ b/pkg/framework/core/allure_manager/ctx/hooks.go
@@ -48,13 +48,13 @@ func (ctx *hooksCtx) GetName() string {
 	return ctx.name
 }
 
-// AddAttachment adds attachment to the execution context
-func (ctx *hooksCtx) AddAttachment(attachment *allure.Attachment) {
+// AddAttachments adds attachment to the execution context
+func (ctx *hooksCtx) AddAttachments(attachments ...*allure.Attachment) {
 	newStep := allure.NewSimpleStep(
-		fmt.Sprintf("Attachment %s", attachment.Name),
-		allure.NewParameter("name", attachment.Name),
-		allure.NewParameter("type", string(attachment.Type)),
-		allure.NewParameter("source", attachment.Source))
-	newStep.WithAttachments(attachment)
+		fmt.Sprintf("Attachment %s", attachments[0].Name),
+		allure.NewParameter("name", attachments[0].Name),
+		allure.NewParameter("type", string(attachments[0].Type)),
+		allure.NewParameter("source", attachments[0].Source))
+	newStep.WithAttachments(attachments...)
 	ctx.AddStep(newStep)
 }

--- a/pkg/framework/core/allure_manager/ctx/hooks_test.go
+++ b/pkg/framework/core/allure_manager/ctx/hooks_test.go
@@ -64,7 +64,7 @@ func TestHooksCtx_AddStep(t *testing.T) {
 func TestHooksCtx_AddAttachment(t *testing.T) {
 	attach := allure.NewAttachment("testAttach", allure.Text, []byte("test"))
 	beforeAll := hooksCtx{name: constants.BeforeAllContextName, container: &allure.Container{}}
-	beforeAll.AddAttachment(attach)
+	beforeAll.AddAttachments(attach)
 	require.NotEmpty(t, beforeAll.container.Befores)
 	require.Len(t, beforeAll.container.Befores, 1)
 	require.NotEmpty(t, beforeAll.container.Befores[0].Attachments)
@@ -72,7 +72,7 @@ func TestHooksCtx_AddAttachment(t *testing.T) {
 	require.Equal(t, attach, beforeAll.container.Befores[0].Attachments[0])
 
 	beforeEach := hooksCtx{name: constants.BeforeEachContextName, container: &allure.Container{}}
-	beforeEach.AddAttachment(attach)
+	beforeEach.AddAttachments(attach)
 	require.NotEmpty(t, beforeEach.container.Befores)
 	require.Len(t, beforeEach.container.Befores, 1)
 	require.NotEmpty(t, beforeEach.container.Befores[0].Attachments)
@@ -80,7 +80,7 @@ func TestHooksCtx_AddAttachment(t *testing.T) {
 	require.Equal(t, attach, beforeEach.container.Befores[0].Attachments[0])
 
 	afterAll := hooksCtx{name: constants.AfterAllContextName, container: &allure.Container{}}
-	afterAll.AddAttachment(attach)
+	afterAll.AddAttachments(attach)
 	require.NotEmpty(t, afterAll.container.Afters)
 	require.Len(t, afterAll.container.Afters, 1)
 	require.NotEmpty(t, afterAll.container.Afters[0].Attachments)
@@ -88,7 +88,7 @@ func TestHooksCtx_AddAttachment(t *testing.T) {
 	require.Equal(t, attach, afterAll.container.Afters[0].Attachments[0])
 
 	afterEach := hooksCtx{name: constants.AfterEachContextName, container: &allure.Container{}}
-	afterEach.AddAttachment(attach)
+	afterEach.AddAttachments(attach)
 	require.NotEmpty(t, afterEach.container.Afters)
 	require.Len(t, afterEach.container.Afters, 1)
 	require.NotEmpty(t, afterEach.container.Afters[0].Attachments)

--- a/pkg/framework/core/allure_manager/ctx/test_ctx.go
+++ b/pkg/framework/core/allure_manager/ctx/test_ctx.go
@@ -23,6 +23,6 @@ func (ctx *testCtx) GetName() string {
 	return ctx.name
 }
 
-func (ctx *testCtx) AddAttachment(attachment *allure.Attachment) {
-	ctx.result.Attachments = append(ctx.result.Attachments, attachment)
+func (ctx *testCtx) AddAttachments(attachments ...*allure.Attachment) {
+	ctx.result.Attachments = append(ctx.result.Attachments, attachments...)
 }

--- a/pkg/framework/core/allure_manager/ctx/test_ctx_test.go
+++ b/pkg/framework/core/allure_manager/ctx/test_ctx_test.go
@@ -1,10 +1,11 @@
 package ctx
 
 import (
+	"testing"
+
 	"github.com/ozontech/allure-go/pkg/allure"
 	"github.com/ozontech/allure-go/pkg/framework/core/constants"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 func TestNewTestCtx(t *testing.T) {
@@ -29,7 +30,7 @@ func TestTestCtx_AddStep(t *testing.T) {
 func TestTestCtx_AddAttachment(t *testing.T) {
 	attach := allure.NewAttachment("testAttach", allure.Text, []byte("test"))
 	test := testCtx{name: constants.TestContextName, result: &allure.Result{}}
-	test.AddAttachment(attach)
+	test.AddAttachments(attach)
 	require.NotEmpty(t, test.result.Attachments)
 	require.Len(t, test.result.Attachments, 1)
 	require.Equal(t, attach, test.result.Attachments[0])

--- a/pkg/framework/core/allure_manager/manager/attachment.go
+++ b/pkg/framework/core/allure_manager/manager/attachment.go
@@ -2,12 +2,12 @@ package manager
 
 import "github.com/ozontech/allure-go/pkg/allure"
 
-// Attachment adds attachment to report in case of current execution context
-func (a *allureManager) Attachment(attachment *allure.Attachment) {
-	a.ExecutionContext().AddAttachment(attachment)
+// WithAttachments adds attachment to report in case of current execution context
+func (a *allureManager) WithAttachments(attachments ...*allure.Attachment) {
+	a.ExecutionContext().AddAttachments(attachments...)
 }
 
-// NewAttachment creates and adds attachment to report in case of current execution context
-func (a *allureManager) NewAttachment(name string, mimeType allure.MimeType, content []byte) {
-	a.ExecutionContext().AddAttachment(allure.NewAttachment(name, mimeType, content))
+// WithNewAttachment creates and adds attachment to report in case of current execution context
+func (a *allureManager) WithNewAttachment(name string, mimeType allure.MimeType, content []byte) {
+	a.ExecutionContext().AddAttachments(allure.NewAttachment(name, mimeType, content))
 }

--- a/pkg/framework/core/allure_manager/manager/attachment_test.go
+++ b/pkg/framework/core/allure_manager/manager/attachment_test.go
@@ -27,8 +27,8 @@ func (m *execMockAttach) AddStep(step *allure.Step) {
 	m.steps = append(m.steps, step)
 }
 
-func (m *execMockAttach) AddAttachment(attachment *allure.Attachment) {
-	m.attach = append(m.attach, attachment)
+func (m *execMockAttach) AddAttachments(attachments ...*allure.Attachment) {
+	m.attach = append(m.attach, attachments...)
 }
 
 func (m *execMockAttach) GetName() string {
@@ -40,7 +40,7 @@ func TestAllureManager_Attachment(t *testing.T) {
 	attach := allure.NewAttachment("testAttach", allure.Text, []byte("test"))
 	manager := allureManager{executionContext: mock}
 
-	manager.Attachment(attach)
+	manager.WithAttachments(attach)
 	require.NotEmpty(t, mock.attach)
 	require.Len(t, mock.attach, 1)
 	require.Equal(t, mock.attach[0], attach)
@@ -49,7 +49,7 @@ func TestAllureManager_Attachment(t *testing.T) {
 func TestAllureManager_NewAttachment(t *testing.T) {
 	mock := newExecMockAttach(constants.TestContextName)
 	manager := allureManager{executionContext: mock}
-	manager.NewAttachment("testAttach", allure.Text, []byte("test"))
+	manager.WithNewAttachment("testAttach", allure.Text, []byte("test"))
 	require.NotEmpty(t, mock.attach)
 	require.Len(t, mock.attach, 1)
 	require.Equal(t, "testAttach", mock.attach[0].Name)

--- a/pkg/framework/core/common/common_test.go
+++ b/pkg/framework/core/common/common_test.go
@@ -3,16 +3,17 @@ package common
 import (
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
+	"os"
+	"sync"
+	"testing"
+
 	"github.com/ozontech/allure-go/pkg/allure"
 	"github.com/ozontech/allure-go/pkg/framework/asserts_wrapper/helper"
 	"github.com/ozontech/allure-go/pkg/framework/core/allure_manager/manager"
 	"github.com/ozontech/allure-go/pkg/framework/core/constants"
 	"github.com/ozontech/allure-go/pkg/framework/provider"
 	"github.com/stretchr/testify/require"
-	"io/ioutil"
-	"os"
-	"sync"
-	"testing"
 )
 
 type executionContextCommMock struct {
@@ -33,8 +34,8 @@ func (m *executionContextCommMock) AddStep(step *allure.Step) {
 	m.steps = append(m.steps, step)
 }
 
-func (m *executionContextCommMock) AddAttachment(attachment *allure.Attachment) {
-	m.attachments = append(m.attachments, attachment)
+func (m *executionContextCommMock) AddAttachments(attachments ...*allure.Attachment) {
+	m.attachments = append(m.attachments, attachments...)
 }
 
 func (m *executionContextCommMock) GetName() string {

--- a/pkg/framework/core/common/step_context.go
+++ b/pkg/framework/core/common/step_context.go
@@ -114,16 +114,7 @@ func (ctx *stepCtx) WithAttachments(attachments ...*allure.Attachment) {
 	ctx.currentStep.WithAttachments(attachments...)
 }
 
-// WithNewAttachment TODO mark deprecated or remove?
 func (ctx *stepCtx) WithNewAttachment(name string, mimeType allure.MimeType, content []byte) {
-	ctx.currentStep.WithAttachments(allure.NewAttachment(name, mimeType, content))
-}
-
-func (ctx *stepCtx) Attachment(attachment *allure.Attachment) {
-	ctx.currentStep.WithAttachments(attachment)
-}
-
-func (ctx *stepCtx) NewAttachment(name string, mimeType allure.MimeType, content []byte) {
 	ctx.currentStep.WithAttachments(allure.NewAttachment(name, mimeType, content))
 }
 

--- a/pkg/framework/core/common/step_context.go
+++ b/pkg/framework/core/common/step_context.go
@@ -114,7 +114,16 @@ func (ctx *stepCtx) WithAttachments(attachments ...*allure.Attachment) {
 	ctx.currentStep.WithAttachments(attachments...)
 }
 
+// WithNewAttachment TODO mark deprecated or remove?
 func (ctx *stepCtx) WithNewAttachment(name string, mimeType allure.MimeType, content []byte) {
+	ctx.currentStep.WithAttachments(allure.NewAttachment(name, mimeType, content))
+}
+
+func (ctx *stepCtx) Attachment(attachment *allure.Attachment) {
+	ctx.currentStep.WithAttachments(attachment)
+}
+
+func (ctx *stepCtx) NewAttachment(name string, mimeType allure.MimeType, content []byte) {
 	ctx.currentStep.WithAttachments(allure.NewAttachment(name, mimeType, content))
 }
 

--- a/pkg/framework/core/common/step_context_test.go
+++ b/pkg/framework/core/common/step_context_test.go
@@ -1,13 +1,14 @@
 package common
 
 import (
+	"sync"
+	"testing"
+	"time"
+
 	"github.com/ozontech/allure-go/pkg/allure"
 	"github.com/ozontech/allure-go/pkg/framework/asserts_wrapper/helper"
 	"github.com/ozontech/allure-go/pkg/framework/core/constants"
 	"github.com/ozontech/allure-go/pkg/framework/provider"
-	"sync"
-	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -88,8 +89,8 @@ func (m *executionCtxMock) AddStep(step *allure.Step) {
 	m.steps = append(m.steps, step)
 }
 
-func (m *executionCtxMock) AddAttachment(attachment *allure.Attachment) {
-	m.attachments = append(m.attachments, attachment)
+func (m *executionCtxMock) AddAttachments(attachments ...*allure.Attachment) {
+	m.attachments = append(m.attachments, attachments...)
 }
 
 func (m *executionCtxMock) GetName() string {

--- a/pkg/framework/core/common/steps_test.go
+++ b/pkg/framework/core/common/steps_test.go
@@ -30,8 +30,8 @@ func (m *executionContextstepsCommMock) AddStep(step *allure.Step) {
 	m.steps = append(m.steps, step)
 }
 
-func (m *executionContextstepsCommMock) AddAttachment(attachment *allure.Attachment) {
-	m.attachments = append(m.attachments, attachment)
+func (m *executionContextstepsCommMock) AddAttachments(attachments ...*allure.Attachment) {
+	m.attachments = append(m.attachments, attachments...)
 }
 
 func (m *executionContextstepsCommMock) GetName() string {

--- a/pkg/framework/provider/allure.go
+++ b/pkg/framework/provider/allure.go
@@ -51,8 +51,8 @@ type AllureSteps interface {
 }
 
 type Attachments interface {
-	Attachment(attachment *allure.Attachment)
-	NewAttachment(name string, mimeType allure.MimeType, content []byte)
+	WithAttachments(attachment ...*allure.Attachment)
+	WithNewAttachment(name string, mimeType allure.MimeType, content []byte)
 }
 
 type AllureForward interface {

--- a/pkg/framework/provider/provider.go
+++ b/pkg/framework/provider/provider.go
@@ -52,6 +52,6 @@ type SuiteMeta interface {
 
 type ExecutionContext interface {
 	AddStep(step *allure.Step)
-	AddAttachment(attachment *allure.Attachment)
+	AddAttachments(attachment ...*allure.Attachment)
 	GetName() string
 }

--- a/pkg/framework/provider/test.go
+++ b/pkg/framework/provider/test.go
@@ -42,9 +42,7 @@ type StepCtx interface {
 	WithParameters(parameters ...allure.Parameter)
 	WithNewParameters(kv ...interface{})
 
-	Attachment(attachment *allure.Attachment)
-	NewAttachment(name string, mimeType allure.MimeType, content []byte)
-	WithAttachments(attachments ...*allure.Attachment)
+	WithAttachments(attachment ...*allure.Attachment)
 	WithNewAttachment(name string, mimeType allure.MimeType, content []byte)
 
 	Fail()

--- a/pkg/framework/provider/test.go
+++ b/pkg/framework/provider/test.go
@@ -34,15 +34,21 @@ type StepCtx interface {
 	Error(args ...interface{})
 	Errorf(format string, args ...interface{})
 
+	Step(step *allure.Step)
+	NewStep(stepName string, parameters ...allure.Parameter)
 	WithNewStep(stepName string, step func(ctx StepCtx), params ...allure.Parameter)
 	WithNewAsyncStep(stepName string, step func(ctx StepCtx), params ...allure.Parameter)
+
 	WithParameters(parameters ...allure.Parameter)
 	WithNewParameters(kv ...interface{})
+
+	Attachment(attachment *allure.Attachment)
+	NewAttachment(name string, mimeType allure.MimeType, content []byte)
 	WithAttachments(attachments ...*allure.Attachment)
 	WithNewAttachment(name string, mimeType allure.MimeType, content []byte)
-	NewStep(stepName string, parameters ...allure.Parameter)
-	Step(step *allure.Step)
+
 	Fail()
+	FailNow()
 	Broken()
 
 	Assert() Asserts

--- a/pkg/framework/runner/runner_test.go
+++ b/pkg/framework/runner/runner_test.go
@@ -32,8 +32,8 @@ func (m *executionContextRunnerMock) AddStep(step *allure.Step) {
 	m.steps = append(m.steps, step)
 }
 
-func (m *executionContextRunnerMock) AddAttachment(attachment *allure.Attachment) {
-	m.attachments = append(m.attachments, attachment)
+func (m *executionContextRunnerMock) AddAttachments(attachments ...*allure.Attachment) {
+	m.attachments = append(m.attachments, attachments...)
 }
 
 func (m *executionContextRunnerMock) GetName() string {


### PR DESCRIPTION
Для поддержки схожести структур T и stepContext предлагаю поддержать `type Attachments interface` и так же добавить `FailNow()`