### PR TITLE
Change message error, when suite was not created (error in beforeAll/beforeEach)

### DIFF
--- a/pkg/framework/runner/runner.go
+++ b/pkg/framework/runner/runner.go
@@ -178,14 +178,14 @@ func (r *runner) RunTests() map[string]bool {
 		ok, err := runHook(r.internalT, beforeAllHook)
 		if err != nil {
 			for _, testMeta := range r.tests {
-				handleError("Suite Setup failed", err, testMeta.testMeta.GetResult())
+				handleError(fmt.Sprintf("%v setup was failed", r.internalT.Name()), err, testMeta.testMeta.GetResult())
 				finishTest(testMeta.testMeta)
 			}
 			return
 		}
 		if !ok {
 			for _, testMeta := range r.tests {
-				handleError("Suite Setup failed", fmt.Errorf("some assertion error during Suite Setup"), testMeta.testMeta.GetResult())
+				handleError(fmt.Sprintf("%v setup was failed", r.internalT.Name()), fmt.Errorf("something goes wrong in beforeAll/afterAll/beforeEach/afterEach"), testMeta.testMeta.GetResult())
 				finishTest(testMeta.testMeta)
 			}
 			return

--- a/pkg/framework/runner/runner.go
+++ b/pkg/framework/runner/runner.go
@@ -248,10 +248,10 @@ func Run(t *testing.T, testName string, testBody func(provider.T), tags ...strin
 		newT        = common.NewT(t)
 		callers     = strings.Split(t.Name(), "/")
 		providerCfg = manager.NewProviderConfig().
-			WithFullName(t.Name()).
-			WithPackageName(getPackage(2)).
-			WithSuiteName(t.Name()).
-			WithRunner(callers[0])
+				WithFullName(t.Name()).
+				WithPackageName(getPackage(2)).
+				WithSuiteName(t.Name()).
+				WithRunner(callers[0])
 		newProvider = manager.NewProvider(providerCfg)
 	)
 	newT.SetProvider(newProvider)

--- a/pkg/framework/runner/runner.go
+++ b/pkg/framework/runner/runner.go
@@ -185,7 +185,7 @@ func (r *runner) RunTests() map[string]bool {
 		}
 		if !ok {
 			for _, testMeta := range r.tests {
-				handleError(fmt.Sprintf("%v setup was failed", r.internalT.Name()), fmt.Errorf("something goes wrong in beforeAll/afterAll/beforeEach/afterEach"), testMeta.testMeta.GetResult())
+				handleError(fmt.Sprintf("%v setup was failed", r.internalT.Name()), fmt.Errorf("something goes wrong in beforeAll/beforeEach"), testMeta.testMeta.GetResult())
 				finishTest(testMeta.testMeta)
 			}
 			return
@@ -248,10 +248,10 @@ func Run(t *testing.T, testName string, testBody func(provider.T), tags ...strin
 		newT        = common.NewT(t)
 		callers     = strings.Split(t.Name(), "/")
 		providerCfg = manager.NewProviderConfig().
-				WithFullName(t.Name()).
-				WithPackageName(getPackage(2)).
-				WithSuiteName(t.Name()).
-				WithRunner(callers[0])
+			WithFullName(t.Name()).
+			WithPackageName(getPackage(2)).
+			WithSuiteName(t.Name()).
+			WithRunner(callers[0])
 		newProvider = manager.NewProvider(providerCfg)
 	)
 	newT.SetProvider(newProvider)


### PR DESCRIPTION
**Old:**

<img width="1611" alt="image" src="https://user-images.githubusercontent.com/33636772/184349016-427f6040-097b-4fe7-8ef8-12d0d220d294.png">

**New:**

<img width="1602" alt="image" src="https://user-images.githubusercontent.com/33636772/184350297-c098526c-1b90-4907-81a4-121e7aa8d8e2.png">

```
func TestV2(t *testing.T) {
	suite.RunSuite(t, new(v2.Suite))
}
```