### PR TITLE
add TmsLink and TmsLinks support

### DIFF
--- a/pkg/allure/config.go
+++ b/pkg/allure/config.go
@@ -8,6 +8,7 @@ const (
 	outputFolderEnvKey    = "ALLURE_OUTPUT_FOLDER"    // Indicates the name of the folder to print the results.
 	issuePatternEnvKey    = "ALLURE_ISSUE_PATTERN"    // Indicates the URL pattern for Issue. It must contain exactly one `%s`
 	testCasePatternEnvKey = "ALLURE_TESTCASE_PATTERN" // Indicates the URL pattern for TestCase. It must contain exactly one `%s`
+	tmsLinkPatternEnvKey  = "ALLURE_LINK_TMS_PATTERN" // Indicates the URL pattern for TmsLink. It must contain exactly one `%s`
 
 	defaultTagsEnvKey = "ALLURE_LAUNCH_TAGS" // Indicates the default tags that will mark all tests in the run. The tags must be specified separated by commas.
 

--- a/pkg/allure/config_test.go
+++ b/pkg/allure/config_test.go
@@ -11,5 +11,6 @@ func TestConfig(t *testing.T) {
 	require.Equal(t, "ALLURE_ISSUE_PATTERN", issuePatternEnvKey)
 	require.Equal(t, "ALLURE_TESTCASE_PATTERN", testCasePatternEnvKey)
 	require.Equal(t, "ALLURE_LAUNCH_TAGS", defaultTagsEnvKey)
+	require.Equal(t, "ALLURE_TMS_LINK_PATTERN", tmsLinkPatternEnvKey)
 	require.Equal(t, 0644, fileSystemPermissionCode)
 }

--- a/pkg/allure/config_test.go
+++ b/pkg/allure/config_test.go
@@ -11,6 +11,6 @@ func TestConfig(t *testing.T) {
 	require.Equal(t, "ALLURE_ISSUE_PATTERN", issuePatternEnvKey)
 	require.Equal(t, "ALLURE_TESTCASE_PATTERN", testCasePatternEnvKey)
 	require.Equal(t, "ALLURE_LAUNCH_TAGS", defaultTagsEnvKey)
-	require.Equal(t, "ALLURE_TMS_LINK_PATTERN", tmsLinkPatternEnvKey)
+	require.Equal(t, "ALLURE_LINK_TMS_PATTERN", tmsLinkPatternEnvKey)
 	require.Equal(t, 0644, fileSystemPermissionCode)
 }

--- a/pkg/allure/link.go
+++ b/pkg/allure/link.go
@@ -25,6 +25,7 @@ const (
 	LINK     LinkTypes = "link"
 	ISSUE    LinkTypes = "issue"
 	TESTCASE LinkTypes = "test_case"
+	TMS      LinkTypes = "tms"
 )
 
 // NewLink Constructor. Builds and returns a new `allure.Link` object.
@@ -49,12 +50,30 @@ func LinkLink(linkname, link string) *Link {
 	return NewLink(linkname, LINK, link)
 }
 
+// TmsLink returns TMS type link
+func TmsLink(testCase string) *Link {
+	return NewLink(testCase, TMS, fmt.Sprintf(getTmsPattern(), testCase))
+}
+
+// TmsLinks returns multiple TmsLink type link
+func TmsLinks(testCases ...string) []*Link {
+	var result []*Link
+	for _, testCase := range testCases {
+		result = append(result, NewLink(testCase, TMS, fmt.Sprintf(getTmsPattern(), testCase)))
+	}
+	return result
+}
+
 func getIssuePattern() string {
 	return getPattern(issuePatternEnvKey, "%s")
 }
 
 func getTestCasePattern() string {
 	return getPattern(testCasePatternEnvKey, "%s")
+}
+
+func getTmsPattern() string {
+	return getPattern(tmsLinkPatternEnvKey, "%s")
 }
 
 func getPattern(envKey string, defaultPattern string) string {

--- a/pkg/allure/link_test.go
+++ b/pkg/allure/link_test.go
@@ -11,16 +11,19 @@ func TestLinkTypes(t *testing.T) {
 	link := "link"
 	issue := "issue"
 	testCase := "test_case"
+	tms := "tms"
 
 	require.Equal(t, link, string(LINK))
 	require.Equal(t, issue, string(ISSUE))
 	require.Equal(t, testCase, string(TESTCASE))
+	require.Equal(t, tms, string(TMS))
 }
 
 func TestNewLink(t *testing.T) {
 	link := NewLink("testLink", LINK, "https://www.testLink.com")
 	issue := NewLink("issueLink", ISSUE, "https://www.testIssue.com")
 	testCase := NewLink("testCaseLink", TESTCASE, "https://www.testCase.com")
+	tms := NewLink("tmsLink", TMS, "https://www.tmslink.com")
 
 	require.NotNil(t, link)
 	require.Equal(t, "testLink", link.Name)
@@ -36,6 +39,11 @@ func TestNewLink(t *testing.T) {
 	require.Equal(t, "testCaseLink", testCase.Name)
 	require.Equal(t, string(TESTCASE), testCase.Type)
 	require.Equal(t, "https://www.testCase.com", testCase.URL)
+
+	require.NotNil(t, tms)
+	require.Equal(t, "tmsLink", tms.Name)
+	require.Equal(t, string(TMS), tms.Type)
+	require.Equal(t, "https://www.tmslink.com", tms.URL)
 }
 
 func TestTestCaseLink_noEnv(t *testing.T) {
@@ -72,4 +80,48 @@ func TestIssueLink_Env(t *testing.T) {
 	require.Equal(t, "Issue[TEST-112]", testCase.Name)
 	require.Equal(t, string(ISSUE), testCase.Type)
 	require.Equal(t, "https://jira-mock.com/TEST-112", testCase.URL)
+}
+
+func TestTmsLink_noEnv(t *testing.T) {
+	testCase := TmsLink("TMS-112")
+	require.NotNil(t, testCase)
+	require.Equal(t, "TMS-112", testCase.Name)
+	require.Equal(t, string(TMS), testCase.Type)
+	require.Equal(t, "TMS-112", testCase.URL)
+}
+
+func TestTmsLink_Env(t *testing.T) {
+	os.Setenv(tmsLinkPatternEnvKey, "https://tms-mock.com/%s")
+	defer os.Setenv(tmsLinkPatternEnvKey, "")
+	testCase := TmsLink("TMS-112")
+	require.NotNil(t, testCase)
+	require.Equal(t, "TMS-112", testCase.Name)
+	require.Equal(t, string(TMS), testCase.Type)
+	require.Equal(t, "https://tms-mock.com/TMS-112", testCase.URL)
+}
+
+func TestTmsLinks_noEnv(t *testing.T) {
+	testCase := TmsLinks("TMS-110", "TMS-112")
+	require.NotNil(t, testCase)
+	require.Len(t, testCase, 2)
+	require.Equal(t, "TMS-110", testCase[0].Name)
+	require.Equal(t, "TMS-112", testCase[1].Name)
+	require.Equal(t, string(TMS), testCase[0].Type)
+	require.Equal(t, string(TMS), testCase[1].Type)
+	require.Equal(t, "TMS-110", testCase[0].URL)
+	require.Equal(t, "TMS-112", testCase[1].URL)
+}
+
+func TestTmsLinks_Env(t *testing.T) {
+	os.Setenv(tmsLinkPatternEnvKey, "https://tms-mock.com/%s")
+	defer os.Setenv(tmsLinkPatternEnvKey, "")
+	testCase := TmsLinks("TEST-110", "TEST-112")
+	require.NotNil(t, testCase)
+	require.Len(t, testCase, 2)
+	require.Equal(t, "TEST-110", testCase[0].Name)
+	require.Equal(t, "TEST-112", testCase[1].Name)
+	require.Equal(t, string(TMS), testCase[0].Type)
+	require.Equal(t, string(TMS), testCase[1].Type)
+	require.Equal(t, "https://tms-mock.com/TEST-110", testCase[0].URL)
+	require.Equal(t, "https://tms-mock.com/TEST-112", testCase[1].URL)
 }

--- a/pkg/framework/core/allure_manager/manager/links.go
+++ b/pkg/framework/core/allure_manager/manager/links.go
@@ -14,9 +14,28 @@ func (a *allureManager) SetTestCase(testCase string) {
 	a.Link(allure.TestCaseLink(testCase))
 }
 
+// TmsLink adds allure external test case link due environment variable ALLURE_TMS_LINK_PATTERN
+func (a *allureManager) TmsLink(testCase string) {
+	a.Link(allure.TmsLink(testCase))
+}
+
+// TmsLinks adds multiple external test case links due environment variable ALLURE_TMS_LINK_PATTERN
+func (a *allureManager) TmsLinks(testCase ...string) {
+	a.Links(allure.TmsLinks(testCase...))
+}
+
 // Link adds Link to struct.AllureResult
 func (a *allureManager) Link(link *allure.Link) {
 	a.safely(func(result *allure.Result) {
 		result.Links = append(result.Links, link)
+	})
+}
+
+// Links adds multiple Link to struct.AllureResult
+func (a *allureManager) Links(links []*allure.Link) {
+	a.safely(func(result *allure.Result) {
+		for _, link := range links {
+			result.Links = append(result.Links, link)
+		}
 	})
 }

--- a/pkg/framework/core/allure_manager/manager/links.go
+++ b/pkg/framework/core/allure_manager/manager/links.go
@@ -34,8 +34,6 @@ func (a *allureManager) Link(link *allure.Link) {
 // Links adds multiple Link to struct.AllureResult
 func (a *allureManager) Links(links []*allure.Link) {
 	a.safely(func(result *allure.Result) {
-		for _, link := range links {
-			result.Links = append(result.Links, link)
-		}
+		result.Links = append(result.Links, links...)
 	})
 }

--- a/pkg/framework/core/allure_manager/manager/links_test.go
+++ b/pkg/framework/core/allure_manager/manager/links_test.go
@@ -69,3 +69,23 @@ func TestAllureManager_SetIssue(t *testing.T) {
 	require.Equal(t, "Issue[Issue]", manager.GetResult().Links[0].Name)
 	require.Equal(t, string(allure.ISSUE), manager.GetResult().Links[0].Type)
 }
+
+func TestAllureManager_TmsLink(t *testing.T) {
+	manager := allureManager{testMeta: &testMetaMockLinks{result: &allure.Result{}}}
+	manager.TmsLink("TmsLink")
+	require.NotEmpty(t, manager.GetResult().Links)
+	require.Len(t, manager.GetResult().Links, 1)
+	require.Equal(t, "TmsLink", manager.GetResult().Links[0].Name)
+	require.Equal(t, string(allure.TMS), manager.GetResult().Links[0].Type)
+}
+
+func TestAllureManager_TmsLinks(t *testing.T) {
+	manager := allureManager{testMeta: &testMetaMockLinks{result: &allure.Result{}}}
+	manager.TmsLinks("TmsLink1", "TmsLink2")
+	require.NotEmpty(t, manager.GetResult().Links)
+	require.Len(t, manager.GetResult().Links, 2)
+	require.Equal(t, "TmsLink1", manager.GetResult().Links[0].Name)
+	require.Equal(t, "TmsLink2", manager.GetResult().Links[1].Name)
+	require.Equal(t, string(allure.TMS), manager.GetResult().Links[0].Type)
+	require.Equal(t, string(allure.TMS), manager.GetResult().Links[1].Type)
+}

--- a/pkg/framework/provider/allure.go
+++ b/pkg/framework/provider/allure.go
@@ -39,6 +39,8 @@ type Links interface {
 	SetIssue(issue string)
 	SetTestCase(testCase string)
 	Link(link *allure.Link)
+	TmsLink(tmsCase string)
+	TmsLinks(tmsCases ...string)
 }
 
 type DescriptionFields interface {


### PR DESCRIPTION
Description
Added support for TmsLink and TmsLinks in Allure according to the [docs](https://docs.qameta.io/allure-report/#_links)
```
func TestSomething(t *testing.T) {
	t.TmsLink("TMS-112")
}
```
or 
```
func TestSomething(t *testing.T) {
	t.TmsLinks("TMS-110","TMS-112")
}
```