### PR TITLE
[ISSUE-84] support helper

### DIFF
--- a/pkg/framework/core/common/common.go
+++ b/pkg/framework/core/common/common.go
@@ -354,6 +354,10 @@ func (c *Common) SetRealT(realT provider.TestingT) {
 	c.TestingT = realT
 }
 
+func (c *Common) GetRealT() provider.TestingT {
+	return c.TestingT
+}
+
 func copyLabels(input, target *allure.Result) *allure.Result {
 	if input == nil || target == nil {
 		return target

--- a/pkg/framework/core/common/common.go
+++ b/pkg/framework/core/common/common.go
@@ -99,6 +99,11 @@ func (c *Common) SkipOnPrint() {
 	c.GetResult().SkipOnPrint()
 }
 
+// Helper ...
+func (c *Common) Helper() {
+	c.TestingT.Helper()
+}
+
 // LogStep ...
 func (c *Common) LogStep(args ...interface{}) {
 	c.Provider.Step(allure.NewSimpleStep(fmt.Sprintln(args...)))
@@ -113,6 +118,8 @@ func (c *Common) LogfStep(format string, args ...interface{}) {
 
 // Error ...
 func (c *Common) Error(args ...interface{}) {
+	c.TestingT.Helper()
+
 	fullMessage := fmt.Sprintf("%s", args...)
 	c.registerError(fullMessage)
 	c.TestingT.Error(args...)
@@ -120,6 +127,8 @@ func (c *Common) Error(args ...interface{}) {
 
 // Errorf ...
 func (c *Common) Errorf(format string, args ...interface{}) {
+	c.TestingT.Helper()
+
 	fullMessage := fmt.Sprintf(format, args...)
 	c.registerError(fullMessage)
 	c.TestingT.Errorf(format, args...)
@@ -127,6 +136,8 @@ func (c *Common) Errorf(format string, args ...interface{}) {
 
 // Fatal ...
 func (c *Common) Fatal(args ...interface{}) {
+	c.TestingT.Helper()
+
 	fullMessage := fmt.Sprintf("%s", args...)
 	c.registerError(fullMessage)
 	c.TestingT.Fatal(args...)
@@ -134,6 +145,8 @@ func (c *Common) Fatal(args ...interface{}) {
 
 // Fatalf ...
 func (c *Common) Fatalf(format string, args ...interface{}) {
+	c.TestingT.Helper()
+
 	fullMessage := fmt.Sprintf(format, args...)
 	c.registerError(fullMessage)
 	c.TestingT.Fatalf(format, args...)

--- a/pkg/framework/core/common/common.go
+++ b/pkg/framework/core/common/common.go
@@ -99,11 +99,6 @@ func (c *Common) SkipOnPrint() {
 	c.GetResult().SkipOnPrint()
 }
 
-// Helper ...
-func (c *Common) Helper() {
-	c.TestingT.Helper()
-}
-
 // LogStep ...
 func (c *Common) LogStep(args ...interface{}) {
 	c.Provider.Step(allure.NewSimpleStep(fmt.Sprintln(args...)))

--- a/pkg/framework/core/common/common_test.go
+++ b/pkg/framework/core/common/common_test.go
@@ -220,6 +220,8 @@ func (m *commonTMock) Run(testName string, testBody func(t *testing.T)) bool {
 	return m.run
 }
 
+func (m *commonTMock) Helper() {}
+
 func TestCommon_Assert(t *testing.T) {
 	asserts := helper.NewAssertsHelper(newCommonTMock())
 	comm := Common{assert: asserts}

--- a/pkg/framework/core/common/common_test.go
+++ b/pkg/framework/core/common/common_test.go
@@ -184,6 +184,7 @@ type commonTMock struct {
 	parallel   bool
 	run        bool
 	skipped    bool
+	TestingT   *testing.T
 }
 
 func newCommonTMock() *commonTMock {

--- a/pkg/framework/core/common/step_context.go
+++ b/pkg/framework/core/common/step_context.go
@@ -28,6 +28,7 @@ type StepT interface {
 	BrokenNow()
 	Name() string
 	Helper()
+	GetRealT() provider.TestingT
 }
 
 type InternalStepCtx interface {
@@ -92,31 +93,31 @@ func (ctx *stepCtx) FailNow() {
 }
 
 func (ctx *stepCtx) Helper() {
-	ctx.t.Helper()
+	ctx.t.GetRealT().Helper()
 }
 
 func (ctx *stepCtx) Error(args ...interface{}) {
-	ctx.t.Helper()
+	ctx.t.GetRealT().Helper()
 
 	ctx.Fail()
 	ctx.t.Error(args...)
 }
 
 func (ctx *stepCtx) Errorf(format string, args ...interface{}) {
-	ctx.t.Helper()
+	ctx.t.GetRealT().Helper()
 
 	ctx.Fail()
 	ctx.t.Errorf(format, args...)
 }
 
 func (ctx *stepCtx) Log(args ...interface{}) {
-	ctx.t.Helper()
+	ctx.t.GetRealT().Helper()
 
 	ctx.t.Log(args...)
 }
 
 func (ctx *stepCtx) Logf(format string, args ...interface{}) {
-	ctx.t.Helper()
+	ctx.t.GetRealT().Helper()
 
 	ctx.t.Logf(format, args...)
 }

--- a/pkg/framework/core/common/step_context.go
+++ b/pkg/framework/core/common/step_context.go
@@ -27,7 +27,6 @@ type StepT interface {
 	Broken()
 	BrokenNow()
 	Name() string
-	Helper()
 	GetRealT() provider.TestingT
 }
 
@@ -90,10 +89,6 @@ func (ctx *stepCtx) ExecutionContextName() string {
 func (ctx *stepCtx) FailNow() {
 	ctx.Fail()
 	ctx.t.FailNow()
-}
-
-func (ctx *stepCtx) Helper() {
-	ctx.t.GetRealT().Helper()
 }
 
 func (ctx *stepCtx) Error(args ...interface{}) {
@@ -225,4 +220,8 @@ func (ctx *stepCtx) Break(args ...interface{}) {
 func (ctx *stepCtx) Breakf(format string, args ...interface{}) {
 	ctx.Broken()
 	ctx.t.Breakf(format, args...)
+}
+
+func (ctx *stepCtx) GetRealT() provider.TestingT {
+	return ctx.t.GetRealT()
 }

--- a/pkg/framework/core/common/step_context.go
+++ b/pkg/framework/core/common/step_context.go
@@ -27,6 +27,7 @@ type StepT interface {
 	Broken()
 	BrokenNow()
 	Name() string
+	Helper()
 }
 
 type InternalStepCtx interface {
@@ -90,21 +91,33 @@ func (ctx *stepCtx) FailNow() {
 	ctx.t.FailNow()
 }
 
+func (ctx *stepCtx) Helper() {
+	ctx.t.Helper()
+}
+
 func (ctx *stepCtx) Error(args ...interface{}) {
+	ctx.t.Helper()
+
 	ctx.Fail()
 	ctx.t.Error(args...)
 }
 
 func (ctx *stepCtx) Errorf(format string, args ...interface{}) {
+	ctx.t.Helper()
+
 	ctx.Fail()
 	ctx.t.Errorf(format, args...)
 }
 
 func (ctx *stepCtx) Log(args ...interface{}) {
+	ctx.t.Helper()
+
 	ctx.t.Log(args...)
 }
 
 func (ctx *stepCtx) Logf(format string, args ...interface{}) {
+	ctx.t.Helper()
+
 	ctx.t.Logf(format, args...)
 }
 

--- a/pkg/framework/core/common/step_context_test.go
+++ b/pkg/framework/core/common/step_context_test.go
@@ -85,9 +85,6 @@ func (m *providerTMockStep) Name() string {
 	return m.name
 }
 
-func (m *providerTMockStep) Helper() {
-}
-
 func (m *providerTMockStep) GetRealT() provider.TestingT {
 	return m.testingT
 }
@@ -262,6 +259,7 @@ func TestStepCtx_Errorf_withParent(t *testing.T) {
 
 func TestStepCtx_Errorf_noParent(t *testing.T) {
 	mockT := new(providerTMockStep)
+	mockT.SetRealT(t)
 	step := allure.NewSimpleStep("testStep")
 	ctx := stepCtx{t: mockT, currentStep: step}
 	ctx.Errorf("test")
@@ -271,6 +269,8 @@ func TestStepCtx_Errorf_noParent(t *testing.T) {
 
 func TestStepCtx_Error_withParent(t *testing.T) {
 	mockT := new(providerTMockStep)
+	mockT.SetRealT(t)
+
 	parentStep := allure.NewSimpleStep("parentStep", allure.NewParameters("paramParent1", "v1", "paramParent2", "v2")...)
 	parentCtx := &stepCtx{t: mockT, currentStep: parentStep}
 	step := allure.NewSimpleStep("testStep")
@@ -283,6 +283,8 @@ func TestStepCtx_Error_withParent(t *testing.T) {
 
 func TestStepCtx_Error_noParent(t *testing.T) {
 	mockT := new(providerTMockStep)
+	mockT.SetRealT(t)
+
 	step := allure.NewSimpleStep("testStep")
 	ctx := stepCtx{t: mockT, currentStep: step}
 	ctx.Error("test")

--- a/pkg/framework/core/common/step_context_test.go
+++ b/pkg/framework/core/common/step_context_test.go
@@ -22,6 +22,8 @@ type providerTMockStep struct {
 	failNow bool
 	failed  bool
 	name    string
+
+	testingT provider.TestingT
 }
 
 func (m *providerTMockStep) Break(args ...interface{}) {
@@ -87,7 +89,11 @@ func (m *providerTMockStep) Helper() {
 }
 
 func (m *providerTMockStep) GetRealT() provider.TestingT {
-	return nil
+	return m.testingT
+}
+
+func (m *providerTMockStep) SetRealT(realT provider.TestingT) {
+	m.testingT = realT
 }
 
 type providerMockStep struct {
@@ -243,6 +249,7 @@ func TestStepCtx_Step(t *testing.T) {
 
 func TestStepCtx_Errorf_withParent(t *testing.T) {
 	mockT := new(providerTMockStep)
+	mockT.SetRealT(t)
 	parentStep := allure.NewSimpleStep("parentStep")
 	parentCtx := &stepCtx{t: mockT, currentStep: parentStep}
 	step := allure.NewSimpleStep("testStep")

--- a/pkg/framework/core/common/step_context_test.go
+++ b/pkg/framework/core/common/step_context_test.go
@@ -86,6 +86,10 @@ func (m *providerTMockStep) Name() string {
 func (m *providerTMockStep) Helper() {
 }
 
+func (m *providerTMockStep) GetRealT() provider.TestingT {
+	return nil
+}
+
 type providerMockStep struct {
 	status allure.Status
 	msg    string

--- a/pkg/framework/core/common/step_context_test.go
+++ b/pkg/framework/core/common/step_context_test.go
@@ -83,6 +83,9 @@ func (m *providerTMockStep) Name() string {
 	return m.name
 }
 
+func (m *providerTMockStep) Helper() {
+}
+
 type providerMockStep struct {
 	status allure.Status
 	msg    string
@@ -102,6 +105,9 @@ func (m *providerMockStep) UpdateResultStatus(msg, trace string) {
 
 func (m *providerMockStep) ExecutionContext() provider.ExecutionContext {
 	return m.executionContext
+}
+
+func (m *providerMockStep) Helper() {
 }
 
 type executionCtxMock struct {

--- a/pkg/framework/provider/test.go
+++ b/pkg/framework/provider/test.go
@@ -70,7 +70,6 @@ type StepCtx interface {
 	Break(args ...interface{})
 	Breakf(format string, args ...interface{})
 	Name() string
-	Helper()
 }
 
 // Asserts ...

--- a/pkg/framework/provider/test.go
+++ b/pkg/framework/provider/test.go
@@ -70,6 +70,7 @@ type StepCtx interface {
 	Break(args ...interface{})
 	Breakf(format string, args ...interface{})
 	Name() string
+	Helper()
 }
 
 // Asserts ...


### PR DESCRIPTION
1) **Support** `Helper()` in `StepCtx`
2) **Add helper to** `Error()` and `ErrorF`
This is needed for correct tracing inside the test.

Test: `bla_test.go`
```go
func TestName(t *testing.T) {
	runner.Run(t, "Single test with allure-go Runner", func(t provider.T) {
		t.Epic("Compare with allure-go")
		t.Description("New Test Description")
		t.WithNewStep("Step description", func(ctx provider.StepCtx) {
			ctx.Errorf("Error message")
		})
	})
}

func TestName1(t *testing.T) {
	runner.Run(t, "Single test with allure-go Runner", func(t provider.T) {
		t.Errorf("Error message")
	})
}
```

**Logs without helper:**

```
=== RUN   TestName
=== RUN   TestName/Single_test_with_allure-go_Runner
    common.go:125: Error message
--- FAIL: TestName (0.00s)
    --- FAIL: TestName/Single_test_with_allure-go_Runner (0.00s)


=== RUN   TestName1
=== RUN   TestName1/Single_test_with_allure-go_Runner
    common.go:125: Error message
--- FAIL: TestName1 (0.00s)
    --- FAIL: TestName1/Single_test_with_allure-go_Runner (0.00s)

```
**Trace from allure:** `common.go:125: Error message` and `common.go:125: Error message`


**Log with helper:**

```
=== RUN   TestName
=== RUN   TestName/Single_test_with_allure-go_Runner
    bla_test.go:15: Error message
--- FAIL: TestName (0.00s)
    --- FAIL: TestName/Single_test_with_allure-go_Runner (0.00s)


=== RUN   TestName1
=== RUN   TestName1/Single_test_with_allure-go_Runner
    bla_test.go:22: Error message 
--- FAIL: TestName1 (0.00s)
    --- FAIL: TestName1/Single_test_with_allure-go_Runner (0.00s)

```

**Trace from test:** `bla_test.go:15: Error message` and `bla_test.go:22: Error message`
