### PR TITLE
issue-55: Set up/Tear down sections are not displayed in tests without suite

### DIFF
--- a/pkg/framework/core/allure_manager/manager/provider.go
+++ b/pkg/framework/core/allure_manager/manager/provider.go
@@ -71,5 +71,8 @@ func (a *allureManager) NewTest(testName, packageName string, tags ...string) {
 }
 
 func (a *allureManager) FinishTest() error {
+	if err := a.testMeta.GetContainer().Done(); err != nil {
+		return err
+	}
 	return a.testMeta.GetResult().Done()
 }

--- a/pkg/framework/core/allure_manager/manager/provider.go
+++ b/pkg/framework/core/allure_manager/manager/provider.go
@@ -71,8 +71,11 @@ func (a *allureManager) NewTest(testName, packageName string, tags ...string) {
 }
 
 func (a *allureManager) FinishTest() error {
-	if err := a.testMeta.GetContainer().Done(); err != nil {
-		return err
+	container := a.testMeta.GetContainer()
+	if container != nil {
+		if err := container.Done(); err != nil {
+			return err
+		}
 	}
 	return a.testMeta.GetResult().Done()
 }


### PR DESCRIPTION
Fixed [ISSUE-55](https://github.com/ozontech/allure-go/issues/55).

Report for a single test will look like:

<img width="660" alt="Снимок экрана 2024-06-10 в 10 47 27" src="https://github.com/ozontech/allure-go/assets/6352927/6bb06b06-f0e0-4be0-acf1-4ea0093d7af4">
