### PR TITLE
Added api to get test status in after hooks

### DIFF
--- a/pkg/allure/result.go
+++ b/pkg/allure/result.go
@@ -43,6 +43,12 @@ type Result struct {
 	ToPrint bool `json:"-"` // If false - the report will not be saved to a file
 }
 
+// CurrentResult Use for getting current test result in AfterEach hook
+type CurrentResult struct {
+	Status        Status       `json:"status,omitempty"`        // Status of the test execution
+	StatusDetails StatusDetail `json:"statusDetails,omitempty"` // Details about the test (for example, errors during test execution will be recorded here)
+}
+
 // NewResult Constructor Builds a new `allure.Result`. Sets the default values for the structure.
 // ================================================
 // |Field Value| Default                          |
@@ -341,4 +347,11 @@ func (result *Result) ToJSON() ([]byte, error) {
 func getMD5Hash(text string) string {
 	hash := md5.Sum([]byte(text))
 	return hex.EncodeToString(hash[:])
+}
+
+func (result *CurrentResult) GetStatusMessage() string {
+	return result.StatusDetails.Message
+}
+func (result *CurrentResult) GetStatusTrace() string {
+	return result.StatusDetails.Trace
 }

--- a/pkg/framework/core/allure_manager/ctx/hooks.go
+++ b/pkg/framework/core/allure_manager/ctx/hooks.go
@@ -9,9 +9,9 @@ import (
 )
 
 type hooksCtx struct {
-	name       string
-	container  *allure.Container
-	testResult *allure.Result // Result of the test (for AfterEach hook)
+	name      string
+	container *allure.Container
+	result    *allure.Result // Result of the test (for AfterEach hook)
 }
 
 // NewAfterAllCtx returns after all context
@@ -25,8 +25,8 @@ func NewAfterEachCtx(container *allure.Container) provider.ExecutionContext {
 }
 
 // NewAfterEachCtxWithResult returns after each context with test result
-func NewAfterEachCtxWithResult(container *allure.Container, testResult *allure.Result) provider.ExecutionContext {
-	return &hooksCtx{container: container, testResult: testResult, name: constants.AfterEachContextName}
+func NewAfterEachCtxWithResult(container *allure.Container, result *allure.Result) provider.ExecutionContext {
+	return &hooksCtx{container: container, result: result, name: constants.AfterEachContextName}
 }
 
 // NewBeforeAllCtx returns before all context
@@ -57,7 +57,7 @@ func (ctx *hooksCtx) GetName() string {
 
 // GetTestResult returns test result if available (for AfterEach hook)
 func (ctx *hooksCtx) GetTestResult() *allure.Result {
-	return ctx.testResult
+	return ctx.result
 }
 
 // AddAttachments adds attachment to the execution context

--- a/pkg/framework/core/allure_manager/ctx/hooks.go
+++ b/pkg/framework/core/allure_manager/ctx/hooks.go
@@ -9,8 +9,9 @@ import (
 )
 
 type hooksCtx struct {
-	name      string
-	container *allure.Container
+	name       string
+	container  *allure.Container
+	testResult *allure.Result // Result of the test (for AfterEach hook)
 }
 
 // NewAfterAllCtx returns after all context
@@ -21,6 +22,11 @@ func NewAfterAllCtx(container *allure.Container) provider.ExecutionContext {
 // NewAfterEachCtx returns after each context
 func NewAfterEachCtx(container *allure.Container) provider.ExecutionContext {
 	return &hooksCtx{container: container, name: constants.AfterEachContextName}
+}
+
+// NewAfterEachCtxWithResult returns after each context with test result
+func NewAfterEachCtxWithResult(container *allure.Container, testResult *allure.Result) provider.ExecutionContext {
+	return &hooksCtx{container: container, testResult: testResult, name: constants.AfterEachContextName}
 }
 
 // NewBeforeAllCtx returns before all context
@@ -47,6 +53,11 @@ func (ctx *hooksCtx) AddStep(newStep *allure.Step) {
 // GetName returns context name
 func (ctx *hooksCtx) GetName() string {
 	return ctx.name
+}
+
+// GetTestResult returns test result if available (for AfterEach hook)
+func (ctx *hooksCtx) GetTestResult() *allure.Result {
+	return ctx.testResult
 }
 
 // AddAttachments adds attachment to the execution context

--- a/pkg/framework/core/allure_manager/ctx/hooks_test.go
+++ b/pkg/framework/core/allure_manager/ctx/hooks_test.go
@@ -1,6 +1,7 @@
 package ctx
 
 import (
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -203,19 +204,17 @@ func TestHooksCtx_GetTestResult_ConcurrentAccess(t *testing.T) {
 
 	// Multiple goroutines reading the result
 	const numGoroutines = 10
-	done := make(chan bool, numGoroutines)
+	var wg sync.WaitGroup
+	wg.Add(numGoroutines)
 
 	for i := 0; i < numGoroutines; i++ {
 		go func() {
+			defer wg.Done()
 			r := ctx.GetTestResult()
 			require.NotNil(t, r)
 			require.Equal(t, allure.Passed, r.Status)
-			done <- true
 		}()
 	}
 
-	// Wait for all goroutines
-	for i := 0; i < numGoroutines; i++ {
-		<-done
-	}
+	wg.Wait()
 }

--- a/pkg/framework/core/allure_manager/ctx/test_ctx.go
+++ b/pkg/framework/core/allure_manager/ctx/test_ctx.go
@@ -24,6 +24,10 @@ func (ctx *testCtx) GetName() string {
 	return ctx.name
 }
 
+func (ctx *testCtx) GetTestResult() *allure.Result {
+	return ctx.result
+}
+
 func (ctx *testCtx) AddAttachments(attachments ...*allure.Attachment) {
 	ctx.result.Attachments = append(ctx.result.Attachments, attachments...)
 }

--- a/pkg/framework/core/allure_manager/ctx/test_ctx_test.go
+++ b/pkg/framework/core/allure_manager/ctx/test_ctx_test.go
@@ -35,3 +35,147 @@ func TestTestCtx_AddAttachment(t *testing.T) {
 	require.Len(t, test.result.Attachments, 1)
 	require.Equal(t, attach, test.result.Attachments[0])
 }
+
+// Tests for GetTestResult functionality in test context
+func TestTestCtx_GetTestResult(t *testing.T) {
+	result := allure.NewResult("TestName", "TestFullName")
+	result.Status = allure.Passed
+
+	testCtx := NewTestCtx(result)
+
+	retrievedResult := testCtx.GetTestResult()
+	require.NotNil(t, retrievedResult)
+	require.Equal(t, result, retrievedResult)
+	require.Equal(t, allure.Passed, retrievedResult.Status)
+	require.Equal(t, "TestName", retrievedResult.Name)
+}
+
+func TestTestCtx_GetTestResult_WithDifferentStatuses(t *testing.T) {
+	testCases := []struct {
+		name   string
+		status allure.Status
+	}{
+		{"Passed", allure.Passed},
+		{"Failed", allure.Failed},
+		{"Broken", allure.Broken},
+		{"Skipped", allure.Skipped},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := allure.NewResult("Test", "FullTest")
+			result.Status = tc.status
+
+			testCtx := NewTestCtx(result)
+
+			retrievedResult := testCtx.GetTestResult()
+			require.NotNil(t, retrievedResult)
+			require.Equal(t, tc.status, retrievedResult.Status)
+		})
+	}
+}
+
+func TestTestCtx_GetTestResult_NilResult(t *testing.T) {
+	testCtx := testCtx{name: constants.TestContextName, result: nil}
+
+	retrievedResult := testCtx.GetTestResult()
+	require.Nil(t, retrievedResult)
+}
+
+func TestTestCtx_GetName_TestContext(t *testing.T) {
+	result := allure.NewResult("TestName", "TestFullName")
+	testCtx := NewTestCtx(result)
+
+	name := testCtx.GetName()
+	require.Equal(t, constants.TestContextName, name)
+}
+
+// Additional tests for parametrized and nested test scenarios
+func TestTestCtx_GetTestResult_ParametrizedTest(t *testing.T) {
+	// Simulate parametrized test result
+	result := allure.NewResult("TestParametrized", "suite.TestParametrized")
+	result.Status = allure.Passed
+
+	testCtx := NewTestCtx(result)
+
+	retrievedResult := testCtx.GetTestResult()
+	require.NotNil(t, retrievedResult)
+	require.Equal(t, allure.Passed, retrievedResult.Status)
+	require.Equal(t, "TestParametrized", retrievedResult.Name)
+}
+
+func TestTestCtx_GetTestResult_NestedTest(t *testing.T) {
+	// Simulate nested test result
+	result := allure.NewResult("TestNested", "suite.TestNested")
+	result.Status = allure.Passed
+
+	testCtx := NewTestCtx(result)
+
+	retrievedResult := testCtx.GetTestResult()
+	require.NotNil(t, retrievedResult)
+	require.Equal(t, allure.Passed, retrievedResult.Status)
+}
+
+func TestTestCtx_GetTestResult_WithStatusDetails(t *testing.T) {
+	result := allure.NewResult("TestWithDetails", "suite.TestWithDetails")
+	result.Status = allure.Failed
+	result.SetStatusMessage("Assertion failed: expected 1, got 2")
+	result.SetStatusTrace("trace stack here")
+
+	testCtx := NewTestCtx(result)
+
+	retrievedResult := testCtx.GetTestResult()
+	require.NotNil(t, retrievedResult)
+	require.Equal(t, allure.Failed, retrievedResult.Status)
+	require.Equal(t, "Assertion failed: expected 1, got 2", retrievedResult.GetStatusMessage())
+	require.Equal(t, "trace stack here", retrievedResult.GetStatusTrace())
+}
+
+func TestTestCtx_GetTestResult_BrokenTest(t *testing.T) {
+	result := allure.NewResult("BrokenTest", "suite.BrokenTest")
+	result.Status = allure.Broken
+	result.SetStatusMessage("Panic occurred")
+
+	testCtx := NewTestCtx(result)
+
+	retrievedResult := testCtx.GetTestResult()
+	require.NotNil(t, retrievedResult)
+	require.Equal(t, allure.Broken, retrievedResult.Status)
+	require.Contains(t, retrievedResult.GetStatusMessage(), "Panic occurred")
+}
+
+func TestTestCtx_GetTestResult_SkippedTest(t *testing.T) {
+	result := allure.NewResult("SkippedTest", "suite.SkippedTest")
+	result.Status = allure.Skipped
+	result.SetStatusMessage("Test skipped")
+
+	testCtx := NewTestCtx(result)
+
+	retrievedResult := testCtx.GetTestResult()
+	require.NotNil(t, retrievedResult)
+	require.Equal(t, allure.Skipped, retrievedResult.Status)
+}
+
+// Test concurrent access to result
+func TestTestCtx_GetTestResult_ConcurrentAccess(t *testing.T) {
+	result := allure.NewResult("ConcurrentTest", "suite.ConcurrentTest")
+	result.Status = allure.Passed
+
+	testCtx := NewTestCtx(result)
+
+	const numGoroutines = 20
+	done := make(chan bool, numGoroutines)
+
+	for i := 0; i < numGoroutines; i++ {
+		go func() {
+			r := testCtx.GetTestResult()
+			require.NotNil(t, r)
+			require.Equal(t, allure.Passed, r.Status)
+			done <- true
+		}()
+	}
+
+	for i := 0; i < numGoroutines; i++ {
+		<-done
+	}
+}

--- a/pkg/framework/core/allure_manager/manager/attachment_test.go
+++ b/pkg/framework/core/allure_manager/manager/attachment_test.go
@@ -34,6 +34,10 @@ func (m *execMockAttach) GetName() string {
 	return m.name
 }
 
+func (m *execMockAttach) GetTestResult() *allure.Result {
+	return nil
+}
+
 func TestAllureManager_Attachment(t *testing.T) {
 	mock := newExecMockAttach(constants.TestContextName)
 	attach := allure.NewAttachment("testAttach", allure.Text, []byte("test"))

--- a/pkg/framework/core/allure_manager/manager/execution_management.go
+++ b/pkg/framework/core/allure_manager/manager/execution_management.go
@@ -14,7 +14,7 @@ func (a *allureManager) BeforeEachContext() {
 
 // AfterEachContext initiate after each context
 func (a *allureManager) AfterEachContext() {
-	a.executionContext = ctx.NewAfterEachCtx(a.testMeta.GetContainer())
+	a.executionContext = ctx.NewAfterEachCtxWithResult(a.testMeta.GetContainer(), a.testMeta.GetResult())
 }
 
 // BeforeAllContext initiate before all context

--- a/pkg/framework/core/common/common.go
+++ b/pkg/framework/core/common/common.go
@@ -102,15 +102,19 @@ func (c *Common) GetProvider() provider.Provider {
 }
 
 // GetCurrentTestResult returns the current test result (available in AfterEach hook)
-func (c *Common) GetCurrentTestResult() *allure.Result {
+func (c *Common) GetCurrentTestResult() (result *allure.CurrentResult, ok bool) {
 	if c.Provider != nil && c.Provider.ExecutionContext() != nil {
 		// Only return result in AfterEach context
 		ctxName := c.Provider.ExecutionContext().GetName()
 		if ctxName == constants.AfterEachContextName {
-			return c.Provider.ExecutionContext().GetTestResult()
+			var currentFullResult = c.Provider.ExecutionContext().GetTestResult()
+			return &allure.CurrentResult{
+				Status:        currentFullResult.Status,
+				StatusDetails: currentFullResult.StatusDetails,
+			}, true
 		}
 	}
-	return nil
+	return nil, false
 }
 
 // SkipOnPrint skips creating of report for current test

--- a/pkg/framework/core/common/common.go
+++ b/pkg/framework/core/common/common.go
@@ -101,6 +101,18 @@ func (c *Common) GetProvider() provider.Provider {
 	return c.Provider
 }
 
+// GetCurrentTestResult returns the current test result (available in AfterEach hook)
+func (c *Common) GetCurrentTestResult() *allure.Result {
+	if c.Provider != nil && c.Provider.ExecutionContext() != nil {
+		// Only return result in AfterEach context
+		ctxName := c.Provider.ExecutionContext().GetName()
+		if ctxName == constants.AfterEachContextName {
+			return c.Provider.ExecutionContext().GetTestResult()
+		}
+	}
+	return nil
+}
+
 // SkipOnPrint skips creating of report for current test
 func (c *Common) SkipOnPrint() {
 	c.GetResult().SkipOnPrint()

--- a/pkg/framework/core/common/common_test.go
+++ b/pkg/framework/core/common/common_test.go
@@ -452,10 +452,9 @@ func TestCommon_GetCurrentTestResult_AfterEachContext(t *testing.T) {
 
 	comm := Common{Provider: provider}
 
-	result := comm.GetCurrentTestResult()
+	result, _ := comm.GetCurrentTestResult()
 	require.NotNil(t, result)
 	require.Equal(t, allure.Failed, result.Status)
-	require.Equal(t, "TestName", result.Name)
 	require.Equal(t, "Test failed", result.GetStatusMessage())
 }
 
@@ -475,7 +474,7 @@ func TestCommon_GetCurrentTestResult_NilInTestContext(t *testing.T) {
 
 	comm := Common{Provider: provider}
 
-	result := comm.GetCurrentTestResult()
+	result, _ := comm.GetCurrentTestResult()
 	require.Nil(t, result, "GetCurrentTestResult should return nil in test context")
 }
 
@@ -495,21 +494,23 @@ func TestCommon_GetCurrentTestResult_NilInBeforeEachContext(t *testing.T) {
 
 	comm := Common{Provider: provider}
 
-	result := comm.GetCurrentTestResult()
+	result, _ := comm.GetCurrentTestResult()
 	require.Nil(t, result, "GetCurrentTestResult should return nil in BeforeEach context")
 }
 
 func TestCommon_GetCurrentTestResult_NilProviderOrContext(t *testing.T) {
 	// Test with nil Provider
 	comm := Common{Provider: nil}
-	require.Nil(t, comm.GetCurrentTestResult())
+	res, _ := comm.GetCurrentTestResult()
+	require.Nil(t, res)
 
 	// Test with nil ExecutionContext
 	provider := &providerMockCommon{
 		executionMock: nil,
 	}
 	comm = Common{Provider: provider}
-	require.Nil(t, comm.GetCurrentTestResult())
+	res, _ = comm.GetCurrentTestResult()
+	require.Nil(t, res)
 }
 
 // Mock execution context for testing GetCurrentTestResult

--- a/pkg/framework/core/common/step_context_test.go
+++ b/pkg/framework/core/common/step_context_test.go
@@ -144,6 +144,10 @@ func (m *executionCtxMock) GetName() string {
 	return m.name
 }
 
+func (m *executionCtxMock) GetTestResult() *allure.Result {
+	return nil
+}
+
 func TestNewStepCtx(t *testing.T) {
 	params := allure.NewParameters("p1", "v1", "p2", "v2")
 	ctx := NewStepCtx(

--- a/pkg/framework/core/common/steps_test.go
+++ b/pkg/framework/core/common/steps_test.go
@@ -38,6 +38,10 @@ func (m *executionContextstepsCommMock) GetName() string {
 	return m.name
 }
 
+func (m *executionContextstepsCommMock) GetTestResult() *allure.Result {
+	return nil
+}
+
 type providerMockstepsCommon struct {
 	provider.AllureForwardFull
 	steps         []*allure.Step

--- a/pkg/framework/provider/provider.go
+++ b/pkg/framework/provider/provider.go
@@ -56,4 +56,5 @@ type ExecutionContext interface {
 	AddStep(step *allure.Step)
 	AddAttachments(attachment ...*allure.Attachment)
 	GetName() string
+	GetTestResult() *allure.Result // Returns test result if available (for test and AfterEach contexts)
 }

--- a/pkg/framework/provider/test.go
+++ b/pkg/framework/provider/test.go
@@ -39,6 +39,9 @@ type T interface {
 	WithNewAsyncStep(stepName string, step func(sCtx StepCtx), params ...*allure.Parameter)
 	WithTestSetup(setup func(T))
 	WithTestTeardown(teardown func(T))
+
+	// GetCurrentTestResult returns the current test result (available in AfterEach hook)
+	GetCurrentTestResult() *allure.Result
 }
 
 type StepCtx interface {

--- a/pkg/framework/provider/test.go
+++ b/pkg/framework/provider/test.go
@@ -41,7 +41,7 @@ type T interface {
 	WithTestTeardown(teardown func(T))
 
 	// GetCurrentTestResult returns the current test result (available in AfterEach hook)
-	GetCurrentTestResult() *allure.Result
+	GetCurrentTestResult() (*allure.CurrentResult, bool)
 }
 
 type StepCtx interface {

--- a/pkg/framework/runner/runner.go
+++ b/pkg/framework/runner/runner.go
@@ -195,6 +195,11 @@ func (r *runner) RunTests() SuiteResult {
 
 					// after each hook
 					defer func() {
+						// Set default status to Passed if not set (before AfterEach hook)
+						// This allows AfterEach to see the test status
+						if result := testT.GetProvider().GetResult(); result != nil && result.Status == "" {
+							result.Status = allure.Passed
+						}
 						_, _ = runHook(testT, afterEachHook)
 					}()
 

--- a/pkg/framework/runner/runner_test.go
+++ b/pkg/framework/runner/runner_test.go
@@ -39,6 +39,10 @@ func (m *executionContextRunnerMock) GetName() string {
 	return m.name
 }
 
+func (m *executionContextRunnerMock) GetTestResult() *allure.Result {
+	return nil
+}
+
 type providerMockRunner struct {
 	provider.AllureForwardFull
 


### PR DESCRIPTION
### Access to Test Result in AfterEach Hook
### What was implemented?
Introduced the ability to access the current test result inside the AfterEach hook using the method GetCurrentTestResult().
This method provides the status and details of the just-finished test, allowing users to react to test outcomes directly in the hook.

### How was it implemented?
The test result is stored and made available to the AfterEach hook context after each test execution.
The API exposes GetCurrentTestResult() for use in custom suite hooks, without changing the core test or hook execution logic.

### Why was it added?
This feature allows users to perform custom actions (logging, attachments, cleanup) based on the result of each test.
It improves flexibility for reporting and debugging, making it easier to handle failed, broken, or skipped tests right after they finish.