### PR TITLE
Fix panic on beforeAll fail

### DIFF
--- a/pkg/framework/core/allure_manager/manager/provider.go
+++ b/pkg/framework/core/allure_manager/manager/provider.go
@@ -35,8 +35,18 @@ func (a *allureManager) withResult(f func(r *allure.Result)) {
 }
 
 func (a *allureManager) UpdateResultStatus(msg string, trace string) {
-	a.GetResult().SetStatusMessage(msg)
-	a.GetResult().SetStatusTrace(trace)
+	result := a.GetResult()
+	if result == nil {
+		// If result is nil (e.g., in BeforeAll hook), create a temporary result
+		// This allows error information to be captured even when test hasn't started yet
+		result = allure.NewResult(
+			"Before Hook Execution Error",
+			"Before Hook Execution Error",
+		)
+		result.Status = allure.Broken
+	}
+	result.SetStatusMessage(msg)
+	result.SetStatusTrace(trace)
 }
 
 func (a *allureManager) StopResult(status allure.Status) {

--- a/pkg/framework/core/common/common.go
+++ b/pkg/framework/core/common/common.go
@@ -103,7 +103,9 @@ func (c *Common) GetProvider() provider.Provider {
 
 // SkipOnPrint skips creating of report for current test
 func (c *Common) SkipOnPrint() {
-	c.GetResult().SkipOnPrint()
+	if result := c.GetResult(); result != nil {
+		result.SkipOnPrint()
+	}
 }
 
 // LogStep ...
@@ -187,7 +189,16 @@ func (c *Common) Name() string {
 
 // Fail ...
 func (c *Common) Fail() {
-	c.GetProvider().GetResult().Status = allure.Failed
+	result := c.GetProvider().GetResult()
+	if result == nil {
+		// If result is nil (e.g., in BeforeAll hook), create a temporary result
+		// This allows error information to be captured even when test hasn't started yet
+		result = allure.NewResult(
+			"Before Hook Execution Error",
+			"Before Hook Execution Error",
+		)
+	}
+	result.Status = allure.Failed
 	c.TestingT.Fail()
 }
 


### PR DESCRIPTION
If beforeAll fails, we don't have a result yet, and we need to initialize it before setting the failure status.