### PR TITLE
feat: support allure.Parameter in assert msgAndArgs

### DIFF
--- a/pkg/framework/asserts_wrapper/wrapper/helper.go
+++ b/pkg/framework/asserts_wrapper/wrapper/helper.go
@@ -22,6 +22,19 @@ func (h *assertHelper) getStepName(assertName string, msgAndArgs ...interface{})
 }
 
 func (h *assertHelper) WithNewStep(t TestingT, provider Provider, assertName string, assert func(t TestingT) bool, params []*allure.Parameter, msgAndArgs ...interface{}) bool {
+loop:
+	for i, arg := range msgAndArgs {
+		switch argV := arg.(type) {
+		case allure.Parameter:
+			params = append(params, &argV)
+		case *allure.Parameter:
+			params = append(params, argV)
+		default:
+			msgAndArgs = msgAndArgs[i:]
+			break loop
+		}
+	}
+
 	var (
 		step   = allure.NewSimpleStep(h.getStepName(assertName, msgAndArgs...), params...)
 		result = assert(t)

--- a/pkg/framework/core/common/common.go
+++ b/pkg/framework/core/common/common.go
@@ -1,9 +1,11 @@
 package common
 
 import (
+	"flag"
 	"fmt"
 	"regexp"
 	"runtime/debug"
+	"sort"
 	"strings"
 	"sync"
 	"testing"
@@ -33,6 +35,16 @@ type Common struct {
 	tempDir    string
 	tempDirErr error
 	tempDirSeq int32
+}
+
+// MatchTags supports:
+// - multiple occurrences: -allure-go.tag fast -allure-go.tag smoke
+// - comma separated:      -allure-go.tag fast,smoke
+// Matching is exact against test tags (not regexp).
+var MatchTags = newTagFilter()
+
+func init() {
+	flag.Var(MatchTags, "allure-go.tag", "select tests to run by tag (repeatable, comma-separated)")
 }
 
 // NewT returns Common instance that implementing provider.T interface
@@ -99,6 +111,94 @@ func (c *Common) XSkip() {
 // GetProvider ...
 func (c *Common) GetProvider() provider.Provider {
 	return c.Provider
+}
+
+// Tag adds Tag label to test result and (optionally) applies runtime tag filtering.
+// Note: this filtering happens at runtime, so the test will start executing until Tag/Tags is called.
+func (c *Common) Tag(value string) {
+	if c.Provider != nil {
+		c.Provider.Tag(value)
+	}
+
+	if MatchTags.Empty() {
+		return
+	}
+	if MatchTags.Contains(value) {
+		return
+	}
+
+	c.Skipf("Skipped by -allure-go.tag (selected: %s)", MatchTags.String())
+}
+
+// Tags adds multiple Tag labels to test result and (optionally) applies runtime tag filtering.
+// Note: this filtering happens at runtime, so the test will start executing until Tag/Tags is called.
+func (c *Common) Tags(values ...string) {
+	if c.Provider != nil {
+		c.Provider.Tags(values...)
+	}
+
+	if MatchTags.Empty() {
+		return
+	}
+	for _, v := range values {
+		if MatchTags.Contains(v) {
+			return
+		}
+	}
+
+	c.Skipf("Skipped by -allure-go.tag (selected: %s)", MatchTags.String())
+}
+
+type tagFilterFlag struct {
+	set map[string]struct{}
+}
+
+func newTagFilter() *tagFilterFlag {
+	return &tagFilterFlag{set: make(map[string]struct{})}
+}
+
+func (f *tagFilterFlag) String() string {
+	if f == nil {
+		return ""
+	}
+	keys := make([]string, 0, len(f.set))
+	for k := range f.set {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return strings.Join(keys, ",")
+}
+
+func (f *tagFilterFlag) Set(value string) error {
+	if f.set == nil {
+		f.set = make(map[string]struct{})
+	}
+	if strings.TrimSpace(value) == "" {
+		for k := range f.set {
+			delete(f.set, k)
+		}
+		return nil
+	}
+	for _, part := range strings.Split(value, ",") {
+		tag := strings.TrimSpace(part)
+		if tag == "" {
+			continue
+		}
+		f.set[tag] = struct{}{}
+	}
+	return nil
+}
+
+func (f *tagFilterFlag) Empty() bool {
+	return f == nil || len(f.set) == 0
+}
+
+func (f *tagFilterFlag) Contains(tag string) bool {
+	if f == nil {
+		return false
+	}
+	_, ok := f.set[tag]
+	return ok
 }
 
 // GetCurrentTestResult returns the current test result (available in AfterEach hook)

--- a/pkg/framework/core/common/common_test.go
+++ b/pkg/framework/core/common/common_test.go
@@ -1,6 +1,7 @@
 package common
 
 import (
+	"flag"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -44,6 +45,47 @@ func (m *executionContextCommMock) GetName() string {
 
 func (m *executionContextCommMock) GetTestResult() *allure.Result {
 	return nil
+}
+
+func TestTags_RuntimeFilter(t *testing.T) {
+	if flag.Lookup("allure-go.tag") == nil {
+		flag.String("allure-go.tag", "", "")
+	}
+	require.NoError(t, flag.Set("allure-go.tag", "P0"))
+	defer func() {
+		_ = flag.Set("allure-go.tag", "")
+	}()
+
+	t.Run("mismatch_skips", func(t *testing.T) {
+		c := NewT(t)
+		cfg := manager.NewProviderConfig().
+			WithFullName(t.Name()).
+			WithPackageName("pkg").
+			WithSuiteName("suite").
+			WithRunner("runner")
+		c.SetProvider(manager.NewProvider(cfg))
+
+		defer func() {
+			require.True(t, t.Skipped())
+			require.Equal(t, allure.Skipped, c.GetResult().Status)
+		}()
+
+		c.Tags("P1")
+		t.Fatalf("expected test to be skipped by tag filter")
+	})
+
+	t.Run("match_runs", func(t *testing.T) {
+		c := NewT(t)
+		cfg := manager.NewProviderConfig().
+			WithFullName(t.Name()).
+			WithPackageName("pkg").
+			WithSuiteName("suite").
+			WithRunner("runner")
+		c.SetProvider(manager.NewProvider(cfg))
+
+		c.Tags("P0")
+		require.False(t, t.Skipped())
+	})
 }
 
 type providerMockCommon struct {

--- a/pkg/framework/runner/runner.go
+++ b/pkg/framework/runner/runner.go
@@ -77,6 +77,10 @@ func (r *runner) filterByTestPlan() map[string]Test {
 func (r *runner) NewTest(testName string, testBody func(provider.T), tags ...string) {
 	fullName := fmt.Sprintf("%s/%s", r.t().Name(), testName)
 
+	if !mustTagFilter(tags) {
+		return
+	}
+
 	testMeta := adapter.NewTestMeta(
 		r.t().GetProvider().GetSuiteMeta().GetSuiteFullName(),
 		r.t().GetProvider().GetSuiteMeta().GetSuiteName(),

--- a/pkg/framework/runner/runner_test.go
+++ b/pkg/framework/runner/runner_test.go
@@ -508,3 +508,54 @@ func TestRunner_NewTest(t *testing.T) {
 	r.tests[testKey].GetBody()(r.t())
 	require.True(t, flag)
 }
+
+func TestTagFilter(t *testing.T) {
+	original := matchTags.String()
+	defer func() {
+		require.NoError(t, matchTags.Set(""))
+		if original != "" {
+			require.NoError(t, matchTags.Set(original))
+		}
+	}()
+
+	require.NoError(t, matchTags.Set(""))
+	require.NoError(t, matchTags.Set("fast,smoke"))
+
+	require.True(t, tagFilter([]string{"slow", "smoke"}))
+	require.False(t, tagFilter([]string{"slow"}))
+}
+
+func TestTagFilterFlag_Set(t *testing.T) {
+	filter := common.MatchTags
+	require.NoError(t, filter.Set(""))
+
+	require.NoError(t, filter.Set("fast, smoke"))
+	require.NoError(t, filter.Set("regression"))
+
+	require.True(t, filter.Contains("fast"))
+	require.True(t, filter.Contains("smoke"))
+	require.True(t, filter.Contains("regression"))
+	require.False(t, filter.Contains("slow"))
+}
+
+func TestRunner_NewTest_TagFilter(t *testing.T) {
+	original := matchTags.String()
+	defer func() {
+		require.NoError(t, matchTags.Set(""))
+		if original != "" {
+			require.NoError(t, matchTags.Set(original))
+		}
+	}()
+
+	require.NoError(t, matchTags.Set(""))
+	require.NoError(t, matchTags.Set("fast"))
+
+	r := runner{tests: make(map[string]Test), internalT: newInternalTMock(constants.AfterAllContextName)}
+	r.NewTest("FastTest", func(t provider.T) {}, "fast", "smoke")
+	r.NewTest("SlowTest", func(t provider.T) {}, "slow")
+
+	require.Len(t, r.tests, 1)
+
+	testKey := fmt.Sprintf("%s/%s", r.t().Name(), "FastTest")
+	require.Contains(t, r.tests, testKey)
+}

--- a/pkg/framework/runner/suite_runner.go
+++ b/pkg/framework/runner/suite_runner.go
@@ -289,6 +289,7 @@ func collectHooks(runner *suiteRunner, suite TestSuite) {
 }
 
 var matchMethod = flag.String("allure-go.m", "", "regular expression to select tests of the allure-go suite to run")
+var matchTags = common.MatchTags
 
 var regFilter = newRegFilter()
 
@@ -302,6 +303,24 @@ func methodFilter(name string) (bool, error) {
 	}
 
 	return regexp.MatchString(*matchMethod, name)
+}
+
+func tagFilter(tags []string) bool {
+	if matchTags.Empty() {
+		return true
+	}
+
+	for _, tag := range tags {
+		if matchTags.Contains(tag) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func mustTagFilter(tags []string) bool {
+	return tagFilter(tags)
 }
 
 func newRegFilter() regexp.Regexp {


### PR DESCRIPTION
Currently, assert-related functions do not support adding allure parameters. An additional step is required to describe parameters. This PR enables adding allure parameters directly in assert-related functions, eliminating the need for extra step definitions.

**before:**
```
t.NewStep("Start Task1", allure.NewParameter("Request", req1))
t.Assert().NoError(taskExecutor.StartTask(req1), , "Start Task1")
```
**after:**
```
t.Assert().NoError(taskExecutor.StartTask(req1), allure.NewParameter("Request", req1), "Start Task1")
```